### PR TITLE
Fix off-by-one error preventing ACG security from functioning

### DIFF
--- a/src/node_ls2_handle.cpp
+++ b/src/node_ls2_handle.cpp
@@ -414,7 +414,7 @@ const std::string& LS2Handle::findMyAppId(v8::Isolate* isolate)
     v8::Local<v8::StackTrace> trace = v8::StackTrace::CurrentStackTrace(isolate, 50, v8::StackTrace::kScriptName);
     for(int i = 0; i < trace->GetFrameCount(); i++) {
         std::string scriptName = ConvertFromJS<std::string>(trace->GetFrame(i)->GetScriptName()).value();
-        std::string scriptDirectory = scriptName.substr(0, scriptName.rfind('/'));
+        std::string scriptDirectory = scriptName.substr(0, scriptName.rfind('/') + 1);
         auto serviceInfo = fRegisteredServices.find(scriptDirectory);
         if (serviceInfo != fRegisteredServices.end()) {
             return serviceInfo->second;


### PR DESCRIPTION
LS2Handle::SetAppId() stores the incoming servicePath from
jsservicelauncher/bootstrap* with a trailing "/" at the end.

LS2Handle::findMyAppId() searches for the servicePath with the trailing
"/" stripped.

This change fixes that.

Services with correct ACG configuration will no longer receive "The
service is not registered" errors from the Palmbus module, and so the
webos-service module will allow the ACG functionality to work.

Services without correct ACG configuration will receive "Invalid permissions
for (service id)", and will fall back to using the pre-ACG security. As
webos-service traps the "Invalid permissions" error, it will appear only
as "Deprecated security model is used. Please update configuration for ACG
security model."

Previous to this change, this same error would appear for all services,
regardless of if they had a correct ACG configuration or not.